### PR TITLE
Reworked Framebuffer class to be vastly easier to work with.

### DIFF
--- a/Projects/Renderer/Include/Renderer/LowLevel/Framebuffer.h
+++ b/Projects/Renderer/Include/Renderer/LowLevel/Framebuffer.h
@@ -1,34 +1,80 @@
 #pragma once
 
-
 #include <Framework/CommonTypes.h>
 #include <vulkan/vulkan.h>
 
-#include "VulkanHelpers.h"
+#include "VulkanService.h"
 
 #include <vector>
 
 using vkh = VulkanHelpers;
 
+
+struct FramebufferAttachmentDesc
+{
+	VkFormat Format = VK_FORMAT_R8G8B8A8_UNORM;
+	VkImageAspectFlagBits Aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+	VkClearValue ClearColor = {};
+	VkSampleCountFlagBits MultisampleCount = VK_SAMPLE_COUNT_1_BIT;
+
+	static FramebufferAttachmentDesc CreateColor(VkFormat format, VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT, VkClearColorValue clearColor = { {0,0,0,1} })
+	{
+		FramebufferAttachmentDesc color{};
+		color.Aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+		color.Format = format;
+		color.ClearColor = VkClearValue{ .color = clearColor };
+		color.MultisampleCount = samples;
+		return color;
+	}
+
+	static FramebufferAttachmentDesc CreateDepth(VkFormat format, VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT, VkClearDepthStencilValue clearColor = { 1, 0 })
+	{
+		FramebufferAttachmentDesc depth{};
+		depth.Aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+		depth.Format = format;
+		depth.ClearColor = VkClearValue{ .depthStencil = clearColor };
+		depth.MultisampleCount = samples;
+		return depth;
+	}
+	
+	static FramebufferAttachmentDesc CreateStencil(VkFormat format, VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT, VkClearDepthStencilValue clearColor = { 1, 0 })
+	{
+		FramebufferAttachmentDesc depth{};
+		depth.Aspect = VK_IMAGE_ASPECT_STENCIL_BIT;
+		depth.Format = format;
+		depth.ClearColor = VkClearValue{ .depthStencil = clearColor };
+		depth.MultisampleCount = samples;
+		return depth;
+	}
+	
+	static FramebufferAttachmentDesc CreateResolve(VkFormat format)
+	{
+		FramebufferAttachmentDesc resolve{};
+		resolve.Aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+		resolve.Format = format;
+		resolve.MultisampleCount = VK_SAMPLE_COUNT_1_BIT;
+		return resolve;
+	}
+};	
+
 struct FramebufferDesc
 {
-	VkExtent2D Extent = {};
-	VkFormat Format = {};
-	VkSampleCountFlagBits MsaaSamples;
-	VkRenderPass RenderPass{};
-	std::vector<VkClearValue> ClearValues;
+	VkExtent2D Extent{};
+	std::vector<FramebufferAttachmentDesc> Attachments;
+	u8 OutputAttachmentIndex = 0;
 };
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 class FramebufferResources // NOTE: Not sure if i'm keeping this class - just thrown together for quick renderpasses
 {
-private: // Types
+private:// Types
 	struct Attachment
 	{
-		VkImage Image;
-		VkDeviceMemory ImageMemory;
-		VkImageView ImageView;
+		FramebufferAttachmentDesc Desc;
+		VkImage Image{};
+		VkDeviceMemory ImageMemory{};
+		VkImageView ImageView{};
 
 		void Destroy(VkDevice device, VkAllocationCallbacks* allocator)
 		{
@@ -41,128 +87,73 @@ private: // Types
 		}
 	};
 
-private: // Data
+private:// Data
+	VulkanService& _vk;
 
-private: // Methods
-
-	
 public: // Data
-
 	// Todo make private and provide getters
 	FramebufferDesc Desc = {};
 	VkFramebuffer Framebuffer = nullptr;
 	std::vector<Attachment> Attachments = {};
 	VkImage OutputImage = nullptr;
 	VkDescriptorImageInfo OutputDescriptor = {};
-
+	std::vector<VkClearValue> ClearValues = {};
 
 public: // Methods
 
-	FramebufferResources(const FramebufferDesc& desc, VkDevice device, VkAllocationCallbacks* allocator, VkPhysicalDevice physicalDevice) :
-		Desc{desc}, _device{ device }, _allocator{ allocator }
+	FramebufferResources(const FramebufferDesc& desc, VkRenderPass renderPass, VulkanService& vk) :
+      _vk(vk), Desc{desc}
 	{
+		assert(desc.OutputAttachmentIndex < desc.Attachments.size());
+		
 		const u32 mipLevels = 1;
 		const u32 layerCount = 1;
-		const bool usingMsaa = desc.MsaaSamples > VK_SAMPLE_COUNT_1_BIT;
 
-		Attachments = {};
-
-		
-		// Create color attachment
-		Attachment colorAttachment = {};
+		auto usageFromAspect = [](VkImageAspectFlagBits aspect) -> VkImageUsageFlags
 		{
-			// Create color image and memory
-			std::tie(colorAttachment.Image, colorAttachment.ImageMemory) = vkh::CreateImage2D(
-				desc.Extent.width, desc.Extent.height,
-				mipLevels,
-				desc.MsaaSamples,
-				desc.Format,
-				VK_IMAGE_TILING_OPTIMAL,
-				VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | // renderered to
-				VK_IMAGE_USAGE_SAMPLED_BIT |          // image used in other render passes
-				VK_IMAGE_USAGE_TRANSFER_SRC_BIT |      // image copied into swapchain for presentation
-				VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				physicalDevice, device);
+			VkImageUsageFlags usageFlags =
+            VK_IMAGE_USAGE_SAMPLED_BIT |
+            VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+            VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+			if (aspect & VK_IMAGE_ASPECT_COLOR_BIT)
+				usageFlags |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+			else if (aspect & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+				usageFlags |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+
+			return usageFlags;
+		};			
+		
+		for (const auto& attachmentDesc : desc.Attachments)
+		{
+			Attachment attachment;
+			attachment.Desc = attachmentDesc;
+
+			// Create image
+			std::tie(attachment.Image, attachment.ImageMemory) = vkh::CreateImage2D(
+            desc.Extent.width, desc.Extent.height,
+            mipLevels,
+            attachmentDesc.MultisampleCount,
+            attachmentDesc.Format,
+            VK_IMAGE_TILING_OPTIMAL,
+            usageFromAspect(attachmentDesc.Aspect),
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+            _vk.PhysicalDevice(), _vk.LogicalDevice());
 
 			// Create image view
-			colorAttachment.ImageView = vkh::CreateImage2DView(
-				colorAttachment.Image, 
-				desc.Format, 
-				VK_IMAGE_VIEW_TYPE_2D, 
-				VK_IMAGE_ASPECT_COLOR_BIT,
-				mipLevels, 
-				layerCount, 
-				device);
+			attachment.ImageView = vkh::CreateImage2DView(
+            attachment.Image,
+            attachmentDesc.Format,
+            VK_IMAGE_VIEW_TYPE_2D,
+            attachmentDesc.Aspect,
+            mipLevels,
+            layerCount,
+            _vk.LogicalDevice());
 
-			// Store it
-			Attachments.push_back(colorAttachment);
+			Attachments.emplace_back(attachment);
 		}
-
 		
-		// Create depth attachment
-		Attachment depthAttachment = {};
-		{
-			const VkFormat depthFormat = vkh::FindDepthFormat(physicalDevice);
-
-			// Create depth image and memory
-			std::tie(depthAttachment.Image, depthAttachment.ImageMemory) = vkh::CreateImage2D(
-				desc.Extent.width, desc.Extent.height,
-				mipLevels,
-				desc.MsaaSamples,
-				depthFormat,
-				VK_IMAGE_TILING_OPTIMAL,
-				VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				physicalDevice, device);
-
-			// Create image view
-			depthAttachment.ImageView = vkh::CreateImage2DView(
-				depthAttachment.Image, 
-				depthFormat, 
-				VK_IMAGE_VIEW_TYPE_2D, 
-				VK_IMAGE_ASPECT_DEPTH_BIT, 
-				mipLevels, 
-				layerCount, 
-				device);
-
-			// Store it
-			Attachments.push_back(depthAttachment);
-		}
-
-		
-		// Create optional resolve attachment  -  when msaa is enabled
-		Attachment resolveAttachment = {};
-		if (usingMsaa)
-		{
-			// Create color image and memory
-			std::tie(resolveAttachment.Image, resolveAttachment.ImageMemory) = vkh::CreateImage2D(
-				desc.Extent.width, desc.Extent.height,
-				mipLevels,
-				VK_SAMPLE_COUNT_1_BIT,
-				desc.Format,
-				VK_IMAGE_TILING_OPTIMAL,
-				VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | // renderered to
-				VK_IMAGE_USAGE_SAMPLED_BIT |          // image used in other render passes
-				VK_IMAGE_USAGE_TRANSFER_SRC_BIT |      // image copied into swapchain for presentation
-				VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				physicalDevice, device);
-
-			// Create image view
-			resolveAttachment.ImageView = vkh::CreateImage2DView(
-				resolveAttachment.Image, 
-				desc.Format, 
-				VK_IMAGE_VIEW_TYPE_2D, 
-				VK_IMAGE_ASPECT_COLOR_BIT,
-				mipLevels, 
-				layerCount, 
-				device);
-
-			// Store the resolve goodness
-			Attachments.push_back(resolveAttachment);
-		}
-
 
 		// Collect the views of attachments for use in framebuffer
 		std::vector<VkImageView> framebufferViews = {};
@@ -172,192 +163,38 @@ public: // Methods
 		
 		
 		// Create framebuffer
-		auto* framebuffer = vkh::CreateFramebuffer(device,
-			desc.Extent.width, desc.Extent.height,
-			framebufferViews,
-			desc.RenderPass);
+		auto* framebuffer = vkh::CreateFramebuffer(_vk.LogicalDevice(),
+         desc.Extent.width, desc.Extent.height,
+         framebufferViews,
+         renderPass);
 
 
 		// Color Sampler and co. so it can be sampled from a shader
-		auto* sampler = vkh::CreateSampler(device);
+		auto* sampler = vkh::CreateSampler(_vk.LogicalDevice());
 
 		Framebuffer = framebuffer;
-		OutputImage = usingMsaa ? resolveAttachment.Image : colorAttachment.Image;
-		OutputDescriptor = usingMsaa
-			? VkDescriptorImageInfo{ sampler, resolveAttachment.ImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }
-			: VkDescriptorImageInfo{ sampler, colorAttachment.ImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		OutputImage = Attachments[desc.OutputAttachmentIndex].Image;
+		OutputDescriptor = VkDescriptorImageInfo{
+			sampler,
+         Attachments[desc.OutputAttachmentIndex].ImageView,
+         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+      };
+
+		const auto clearCount = (u32)Attachments.size();
+		ClearValues.resize(clearCount);
+		for (size_t i = 0; i < clearCount; i++)
+		{
+			ClearValues[i] = Attachments[i].Desc.ClearColor;
+		}
 	}
 	
 	void Destroy()
 	{
 		for (auto&& attachment : Attachments) {
-			attachment.Destroy(_device, _allocator);
+			attachment.Destroy(_vk.LogicalDevice(), _vk.Allocator());
 		}
 
-		vkDestroyFramebuffer(_device, Framebuffer, _allocator);
-		vkDestroySampler(_device, OutputDescriptor.sampler, _allocator);
+		vkDestroyFramebuffer(_vk.LogicalDevice(), Framebuffer, _vk.Allocator());
+		vkDestroySampler(_vk.LogicalDevice(), OutputDescriptor.sampler, _vk.Allocator());
 	}
-
-	// TODO Make this less specific to the use case
-	static FramebufferResources CreateSceneFramebuffer(VkExtent2D extent, VkFormat format, VkRenderPass renderPass, VkSampleCountFlagBits msaaSamples, VkDevice device, VkPhysicalDevice physicalDevice, VkAllocationCallbacks* allocator)
-	{		
-		FramebufferDesc desc = {};
-		desc.Extent = extent;
-		desc.Format = format;
-		desc.MsaaSamples = msaaSamples;
-		desc.RenderPass = renderPass;
-
-		desc.ClearValues.resize(2);
-		desc.ClearValues[0].color = { 1.f, 1.f, 0.f, 1.f };
-		desc.ClearValues[1].depthStencil = { 1.f, 0ui32 };
-
-		auto obj = FramebufferResources(desc, device, allocator, physicalDevice);
-		return obj;
-	}
-
-	// TODO Make this less specific to the use case
-	static FramebufferResources CreateShadowFramebuffer(VkExtent2D extent, VkRenderPass renderPass, VkDevice device, VkPhysicalDevice physicalDevice, VkAllocationCallbacks* allocator)
-	{
-		const u32 mipLevels = 1;
-		const u32 layerCount = 1;
-		const auto msaaSamples = VK_SAMPLE_COUNT_1_BIT;
-
-
-		const VkFormat depthFormat = vkh::FindDepthFormat(physicalDevice);
-
-		// Create depth attachment
-		Attachment depthAttachment = {};
-		{
-
-			// Create depth image and memory
-			std::tie(depthAttachment.Image, depthAttachment.ImageMemory) = vkh::CreateImage2D(
-				extent.width, extent.height,
-				mipLevels,
-				msaaSamples,
-				depthFormat,
-				VK_IMAGE_TILING_OPTIMAL,
-				VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				physicalDevice, device);
-
-			// Create image view
-			depthAttachment.ImageView = vkh::CreateImage2DView(
-				depthAttachment.Image,
-				depthFormat,
-				VK_IMAGE_VIEW_TYPE_2D,
-				VK_IMAGE_ASPECT_DEPTH_BIT,
-				mipLevels,
-				layerCount,
-				device);
-		}
-
-
-		// Create framebuffer
-		auto* framebuffer = vkh::CreateFramebuffer(device, extent.width, extent.height,
-			{ depthAttachment.ImageView }, renderPass);
-
-
-		// Sampler so it can be sampled from a shader
-		auto* sampler = vkh::CreateSampler(device,
-			VK_FILTER_LINEAR, VK_FILTER_LINEAR,
-			VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE);
-
-		FramebufferDesc desc = {};
-		desc.Extent = extent;
-		desc.Format = depthFormat;
-		desc.MsaaSamples = msaaSamples;
-		desc.RenderPass = renderPass;
-		
-		desc.ClearValues.resize(1);
-		desc.ClearValues[0].depthStencil = { 1, 0 };
-
-		
-		FramebufferResources res = {};
-		res.Desc = desc;
-		res.Framebuffer = framebuffer;
-		res.Attachments = { depthAttachment };
-		res.OutputImage = depthAttachment.Image;
-		res.OutputDescriptor = VkDescriptorImageInfo{ sampler, depthAttachment.ImageView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL };
-
-		res._device = device;
-		res._allocator = allocator;
-		
-		return res;
-	}
-
-	// TODO Make this less specific to the use case
-	static FramebufferResources CreatePostFramebuffer(VkExtent2D extent, VkFormat format, VkRenderPass renderPass, VkDevice device, VkPhysicalDevice physicalDevice, VkAllocationCallbacks* allocator)
-	{		
-		const u32 mipLevels = 1;
-		const u32 layerCount = 1;
-		const auto msaaSamples = VK_SAMPLE_COUNT_1_BIT;
-
-
-		// Create color attachment
-		Attachment attachment = {};
-		{
-
-			// Create image and memory
-			std::tie(attachment.Image, attachment.ImageMemory) = vkh::CreateImage2D(
-            extent.width, extent.height,
-            mipLevels,
-            msaaSamples,
-            format,
-				VK_IMAGE_TILING_OPTIMAL,
-				VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
-				VK_IMAGE_USAGE_TRANSFER_SRC_BIT |      // image copied into swapchain for presentation
-				VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            physicalDevice, device);
-
-			// Create image view
-			attachment.ImageView = vkh::CreateImage2DView(
-            attachment.Image,
-            format,
-            VK_IMAGE_VIEW_TYPE_2D,
-            VK_IMAGE_ASPECT_COLOR_BIT,
-            mipLevels,
-            layerCount,
-            device);
-		}
-
-
-		// Create framebuffer
-		auto* framebuffer = vkh::CreateFramebuffer(device, extent.width, extent.height,
-         { attachment.ImageView }, renderPass);
-
-
-		// Sampler so it can be sampled from a shader
-		auto* sampler = vkh::CreateSampler(device,
-         VK_FILTER_LINEAR, VK_FILTER_LINEAR,
-         VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE);
-
-		FramebufferDesc desc = {};
-		desc.Extent = extent;
-		desc.Format = format;
-		desc.MsaaSamples = msaaSamples;
-		desc.RenderPass = renderPass;
-		
-		desc.ClearValues.resize(1);
-		desc.ClearValues[0].color = {{0, 1, 0, 1}};
-
-		
-		FramebufferResources res = {};
-		res.Desc = desc;
-		res.Framebuffer = framebuffer;
-		res.Attachments = { attachment };
-		res.OutputImage = attachment.Image;
-		res.OutputDescriptor = VkDescriptorImageInfo{ sampler, attachment.ImageView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL };
-
-		res._device = device;
-		res._allocator = allocator;
-		
-		return res;
-	}
-
-private:
-	VkDevice _device = nullptr;
-	VkAllocationCallbacks* _allocator = nullptr;
-
-	FramebufferResources() = default;
 };

--- a/Projects/Renderer/Include/Renderer/LowLevel/Swapchain.h
+++ b/Projects/Renderer/Include/Renderer/LowLevel/Swapchain.h
@@ -41,8 +41,7 @@ public:
 	inline const std::vector<VkImage>& GetImages() const             { return _images; }
 	inline u32 GetImageCount() const                                 { return _imageCount; }
 	inline VkExtent2D GetExtent() const                              { return _extent; }
-	VkSampleCountFlagBits GetMsaaSamples() const                     { return _msaaSamples; }
-
+	
 
 	Swapchain(VkDevice device, VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, const VkExtent2D& framebufferSize, 
 	          VkSampleCountFlagBits msaaSamples, bool vsync)

--- a/Projects/Renderer/Include/Renderer/LowLevel/VulkanHelpers.h
+++ b/Projects/Renderer/Include/Renderer/LowLevel/VulkanHelpers.h
@@ -168,11 +168,11 @@ public:
 
 
 	[[nodiscard]] static VkImageView CreateImage2DView(VkImage image, VkFormat format, VkImageViewType viewType,
-		VkImageAspectFlagBits aspectFlags, u32 mipLevels, u32 layerCount, VkDevice device);
+		VkImageAspectFlags aspectFlags, u32 mipLevels, u32 layerCount, VkDevice device);
 
 
 	[[nodiscard]] static std::vector<VkImageView> CreateImageViews(const std::vector<VkImage>& images,
-		VkFormat format, VkImageViewType viewType, VkImageAspectFlagBits aspectFlags, u32 mipLevels, u32 layerCount, VkDevice device);
+		VkFormat format, VkImageViewType viewType, VkImageAspectFlags aspectFlags, u32 mipLevels, u32 layerCount, VkDevice device);
 
 
 	/**

--- a/Projects/Renderer/Include/Renderer/LowLevel/VulkanInitializers.h
+++ b/Projects/Renderer/Include/Renderer/LowLevel/VulkanInitializers.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Framework/CommonTypes.h>
-#include "Framebuffer.h"
 #include <vulkan/vulkan.h>
 
 
@@ -157,19 +156,6 @@ namespace vki
 		x.renderArea = renderArea;
 		x.clearValueCount = (u32)clearValues.size();
 		x.pClearValues = clearValues.data();
-		return x;
-	}
-
-	inline VkRenderPassBeginInfo RenderPassBeginInfo(const FramebufferResources& framebuffer, VkRect2D renderArea)
-	{
-		VkRenderPassBeginInfo x = {};
-		x.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-		x.pNext = nullptr;
-		x.renderPass = framebuffer.Desc.RenderPass;
-		x.framebuffer = framebuffer.Framebuffer;
-		x.renderArea = renderArea;
-		x.clearValueCount = (u32)framebuffer.Desc.ClearValues.size();
-		x.pClearValues = framebuffer.Desc.ClearValues.data();
 		return x;
 	}
 	

--- a/Projects/Renderer/Include/Renderer/LowLevel/VulkanService.h
+++ b/Projects/Renderer/Include/Renderer/LowLevel/VulkanService.h
@@ -172,7 +172,9 @@ public: // METHODS /////////////////////////////////////////////////////////////
 	VkAllocationCallbacks* Allocator() const { return nullptr; }
 	
 	void InvalidateSwapchain() { _swapchainInvalidated = true; }
-	
+
+	// Physical Device property
+	VkSampleCountFlagBits GetMsaaSamples() const { return _msaaSamples; }
 	
 	std::optional<std::tuple<u32,VkCommandBuffer>> StartFrame()
 	{

--- a/Projects/Renderer/Source/HighLevel/RenderStages/PbrRenderStage.cpp
+++ b/Projects/Renderer/Source/HighLevel/RenderStages/PbrRenderStage.cpp
@@ -173,7 +173,7 @@ void PbrRenderStage::DestroyRenderer()
 
 void PbrRenderStage::InitRendererResourcesDependentOnSwapchain(u32 numImagesInFlight)
 {
-	auto msaaSamples = _vk.GetSwapchain().GetMsaaSamples(); // TODO This should query the render target
+	auto msaaSamples = _vk.GetMsaaSamples(); // TODO This should query the render target
 	_pbrPipeline = CreatePbrGraphicsPipeline(_shaderDir, _pbrPipelineLayout, msaaSamples, _renderPass, _vk.LogicalDevice());
 
 	_rendererDescriptorPool = CreateDescriptorPool(numImagesInFlight, _vk.LogicalDevice());
@@ -222,7 +222,7 @@ VkRenderPass PbrRenderStage::CreateRenderPass(VkFormat format, VulkanService& vk
 {
 	auto* physicalDevice = vk.PhysicalDevice();
 	auto* device = vk.LogicalDevice();
-	const auto msaaSamples = vk.GetSwapchain().GetMsaaSamples(); // TODO This should query the render target
+	const auto msaaSamples = vk.GetMsaaSamples(); // TODO This should query the render target
 	auto usingMsaa = msaaSamples > VK_SAMPLE_COUNT_1_BIT;
 
 	// Color attachment

--- a/Projects/Renderer/Source/HighLevel/RenderStages/SkyboxRenderStage.cpp
+++ b/Projects/Renderer/Source/HighLevel/RenderStages/SkyboxRenderStage.cpp
@@ -57,7 +57,7 @@ void SkyboxRenderStage::DestroyResources()
 
 void SkyboxRenderStage::InitResourcesDependentOnSwapchain(u32 numImagesInFlight)
 {
-	auto msaaSamples = _vk.GetSwapchain().GetMsaaSamples();  // TODO This should query the render target
+	auto msaaSamples = _vk.GetMsaaSamples();  // TODO This should query the render target
 	_pipeline = CreateGraphicsPipeline(_shaderDir, _pipelineLayout, msaaSamples, _renderPass, _vk.LogicalDevice());
 
 	_descPool = CreateDescPool(numImagesInFlight, _vk.LogicalDevice());
@@ -96,7 +96,7 @@ VkRenderPass SkyboxRenderStage::CreateRenderPass(VkFormat format, VulkanService&
 {
 	auto* physicalDevice = vk.PhysicalDevice();
 	auto* device = vk.LogicalDevice();
-	const auto msaaSamples = vk.GetSwapchain().GetMsaaSamples();  // TODO This should query the render target
+	const auto msaaSamples = vk.GetMsaaSamples();  // TODO This should query the render target
 	auto usingMsaa = msaaSamples > VK_SAMPLE_COUNT_1_BIT;
 
 	// Color attachment

--- a/Projects/Renderer/Source/LowLevel/VulkanHelpers.cpp
+++ b/Projects/Renderer/Source/LowLevel/VulkanHelpers.cpp
@@ -1154,7 +1154,7 @@ std::tuple<VkImage, VkDeviceMemory> VulkanHelpers::CreateImage2D(u32 width, u32 
 }
 
 VkImageView VulkanHelpers::CreateImage2DView(VkImage image, VkFormat format, VkImageViewType viewType,
-	VkImageAspectFlagBits aspectFlags, u32 mipLevels, u32 layerCount, VkDevice device)
+	VkImageAspectFlags aspectFlags, u32 mipLevels, u32 layerCount, VkDevice device)
 {
 	VkImageView imageView;
 
@@ -1182,7 +1182,7 @@ VkImageView VulkanHelpers::CreateImage2DView(VkImage image, VkFormat format, VkI
 }
 
 std::vector<VkImageView> VulkanHelpers::CreateImageViews(const std::vector<VkImage>& images, VkFormat format,
-	VkImageViewType viewType, VkImageAspectFlagBits aspectFlags, u32 mipLevels, u32 layerCount, VkDevice device)
+	VkImageViewType viewType, VkImageAspectFlags aspectFlags, u32 mipLevels, u32 layerCount, VkDevice device)
 {
 	std::vector<VkImageView> imageViews{ images.size() };
 


### PR DESCRIPTION
- Reworked Framebuffer class to be vastly easier to work with.
- Moved GetMsaaSamples query from Swapchain to VulkanService.
- Using VkImageAspectFlags instead of VkImageAspectFlagBits in ImageView helpers.
- Removed circular build dependency of Framebuffer in VulkanInitializers.